### PR TITLE
#1291 EGPD Frequency Update

### DIFF
--- a/Doc/UK VATSIM frequencies.txt
+++ b/Doc/UK VATSIM frequencies.txt
@@ -8,6 +8,9 @@ However, sometimes the frequency published for VATSIM needs to be different. Thi
 
 The following is a list of published UK VATSIM frequencies that differ from their real-world counterpart:
 
+Aberdeen Tower 118.105, 118.100 on VATSIM (8.33kHz-spaced frequency)
+Aberdeen Radar 128.305, 128.300 on VATSIM (8.33kHz-spaced frequency)
+Aberdeen Director 119.055, 119.050 on VATSIM (8.33kHz-spaced frequency)
 Battersea Tower 134.275, 122.900 on VATSIM (New frequency 134.275 introduced in AIRAC 2014/12. Continuing to use old frequency due to conflict with Shannon Information EISN_I_CTR 134.275.)
 Birmingham Approach 123.980, 123.950 on VATSIM (8.33kHz-spaced frequency, 123.970/124.00 unavailable)
 Birmingham Director 131.005, 131.000 on VATSIM (8.33kHz-spaced frequency)


### PR DESCRIPTION
Entered information about the vatsim frequency for EGPD stations due to new 8.33kHz spacing

# Summary of changes

< Added information about the new 8.33kHz frequency's at Aberdeen and the frequencies that will be used instead on the network. >

# Screenshots (if necessary)

< Please provide screenshots if this will facilitate a faster review of these changes - e.g. for SMR creation/updates) >
